### PR TITLE
move the MIN/MAX constants as actual constants

### DIFF
--- a/src/Position.hpp
+++ b/src/Position.hpp
@@ -22,20 +22,20 @@ namespace ais_base {
         STATUS_RESERVED3 = 12,
         STATUS_RESERVED4 = 13,
         STATUS_AIS_SART_ACTIVE = 14,
-        STATUS_NOT_DEFINED = 15,
-
-        STATUS_MIN = 0,
-        STATUS_MAX = 15
+        STATUS_NOT_DEFINED = 15
     };
+
+    static const int STATUS_MIN = 0;
+    static const int STATUS_MAX = 15;
 
     enum ManeuverIndicator {
         MANEUVER_NOT_AVAILABLE = 0,
         MANEUVER_NORMAL = 1,
         MANEUVER_SPECIAL = 2,
-
-        MANEUVER_MIN = 0,
-        MANEUVER_MAX = 2
     };
+
+    static const int MANEUVER_MIN = 0;
+    static const int MANEUVER_MAX = 2;
 
     /** Representation of the data stored in AIS Message 1 to 3 */
     struct Position {

--- a/src/VesselInformation.hpp
+++ b/src/VesselInformation.hpp
@@ -18,10 +18,10 @@ namespace ais_base {
         EPFD_INTEGRATED_NAVIGATION_SYSTEM = 6,
         EPFD_SURVEYED = 7,
         EPFD_GALILEO = 8,
-
-        EPFD_MIN = 0,
-        EPFD_MAX = 8
     };
+
+    static const int EPFD_MIN = 0;
+    static const int EPFD_MAX = 8;
 
     enum ShipType {
         SHIP_TYPE_NOT_AVAILABLE = 0,
@@ -133,10 +133,10 @@ namespace ais_base {
         SHIP_TYPE_RESERVED97 = 97,
         SHIP_TYPE_RESERVED98 = 98,
         SHIP_TYPE_OTHER_NO_INFO = 99,
-
-        SHIP_TYPE_MIN = 0,
-        SHIP_TYPE_MAX = 99
     };
+
+    static const int SHIP_TYPE_MIN = 0;
+    static const int SHIP_TYPE_MAX = 99;
 
     struct VesselInformation {
         base::Time time;


### PR DESCRIPTION
Having them as enums gets annoying in Rock, as the framework
may pick the MIN/MAX constants for display / in the Ruby layer
instead of the actually meaningful constants.