### PR TITLE
feat: add position correction status field

### DIFF
--- a/src/Position.hpp
+++ b/src/Position.hpp
@@ -37,6 +37,12 @@ namespace ais_base {
     static const int MANEUVER_MIN = 0;
     static const int MANEUVER_MAX = 2;
 
+    enum PositionCorrectionStatus {
+        POSITION_RAW = 0,
+        POSITION_CENTERED_USING_HEADING = 1,
+        POSITION_CENTERED_USING_COURSE = 2
+    };
+
     /** Representation of the data stored in AIS Message 1 to 3 */
     struct Position {
     public:
@@ -67,6 +73,7 @@ namespace ais_base {
         ManeuverIndicator maneuver_indicator = MANEUVER_NOT_AVAILABLE;
         bool raim = false;
         uint32_t radio_status = 0;
+        PositionCorrectionStatus correction_status = POSITION_RAW;
 
         Position() = default;
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/simulation-ais_simulation/pull/8

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
[sc-67376]
This PR adds a `PositionCorrectionStatus` enum

# How I did it
<!-- Explain a little bit of your implementation -->
`POSITION_RAW` -> initial value for the `Position` struct
`POSITION_CENTERED_USING_HEADING` -> position was corrected using the vessels heading (`yaw` angle)
`POSITION_CENTERED_USING_COURSE` -> position was corrected using the vessels `course_over_ground` angle.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
